### PR TITLE
작은 이슈들 수정

### DIFF
--- a/VampireSurvivors/Assets/Scenes/MainScene.unity
+++ b/VampireSurvivors/Assets/Scenes/MainScene.unity
@@ -23538,7 +23538,7 @@ MonoBehaviour:
   resultUI: {fileID: 488914680}
   enemyCleaner: {fileID: 842863463}
   gameTime: 0
-  maxGameTime: 20
+  maxGameTime: 300
   isLive: 0
   playerId: 0
   health: 0

--- a/VampireSurvivors/Assets/Scenes/MainScene.unity
+++ b/VampireSurvivors/Assets/Scenes/MainScene.unity
@@ -11809,7 +11809,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   damage: 100000
-  per: -1
+  per: -100
 --- !u!1 &845656697
 GameObject:
   m_ObjectHideFlags: 0

--- a/VampireSurvivors/Assets/Scenes/MainScene.unity
+++ b/VampireSurvivors/Assets/Scenes/MainScene.unity
@@ -18522,6 +18522,7 @@ MonoBehaviour:
     mosterType: 1
     monsterHealth: 15
     monsterSpeed: 2.5
+  levelTime: 0
 --- !u!1 &1533862798
 GameObject:
   m_ObjectHideFlags: 0
@@ -23545,7 +23546,7 @@ MonoBehaviour:
   level: 0
   killPoint: 0
   exp: 0
-  nextExp: 0100000002000000030000000400000005000000060000000600000006000000
+  nextExp: 030000000a0000001e0000006400000096000000d20000001801000068010000c201000058020000
 --- !u!1 &1681178495
 GameObject:
   m_ObjectHideFlags: 0

--- a/VampireSurvivors/Assets/Scripts/Bullet.cs
+++ b/VampireSurvivors/Assets/Scripts/Bullet.cs
@@ -17,18 +17,18 @@ public class Bullet : MonoBehaviour {
 		this.damage = damage;
 		this.per = per;
 
-		if (per > -1) {
+		if (per >= 0) {
 			rigid.velocity = dir * 10f;
 		}
 	}
 
 	private void OnTriggerEnter2D(Collider2D other) {
-		if (!other.CompareTag("Enemy") || per == -1)
+		if (!other.CompareTag("Enemy") || per == -100)
 			return;
 
 		per--;
 
-		if (per == -1) {
+		if (per < 0) {
 			rigid.velocity = Vector2.zero;
 			gameObject.SetActive(false);
 		}

--- a/VampireSurvivors/Assets/Scripts/Bullet.cs
+++ b/VampireSurvivors/Assets/Scripts/Bullet.cs
@@ -23,8 +23,7 @@ public class Bullet : MonoBehaviour {
 	}
 
 	private void OnTriggerEnter2D(Collider2D other) {
-		if (!other.CompareTag("Enemy") || per == -100)
-			return;
+		if (!other.CompareTag("Enemy") || per == -100) return;
 
 		per--;
 
@@ -32,5 +31,11 @@ public class Bullet : MonoBehaviour {
 			rigid.velocity = Vector2.zero;
 			gameObject.SetActive(false);
 		}
+	}
+
+	private void OnTriggerExit2D(Collider2D other) {
+		if (!other.CompareTag("Area") || per == -100) return;
+		
+		gameObject.SetActive(false);
 	}
 }

--- a/VampireSurvivors/Assets/Scripts/GameManager.cs
+++ b/VampireSurvivors/Assets/Scripts/GameManager.cs
@@ -27,7 +27,7 @@ public class GameManager : MonoBehaviour {
     public int level;
     public int killPoint;
     public int exp;
-    public int[] nextExp = { 10, 30, 60, 100, 150, 210, 300, 450 };
+    public int[] nextExp = { 3, 10, 30, 100, 150, 210, 280, 360, 450, 600 };
 
     private void Awake() {
         instance = this;

--- a/VampireSurvivors/Assets/Scripts/Reposition.cs
+++ b/VampireSurvivors/Assets/Scripts/Reposition.cs
@@ -18,15 +18,16 @@ public class Reposition : MonoBehaviour {
 
         Vector3 playerPos = GameManager.instance.player.transform.position;
         Vector3 myPos = transform.position;
-        float diffX = Mathf.Abs(playerPos.x - myPos.x);
-        float diffY = Mathf.Abs(playerPos.y - myPos.y);
-
-        Vector3 playerDir = GameManager.instance.player.inputVec;
-        float dirX = playerDir.x < 0 ? -1 : 1;
-        float dirY = playerDir.y < 0 ? -1 : 1;
 
         switch (transform.tag) {
             case "Ground":
+                float diffX = playerPos.x - myPos.x;
+                float diffY = playerPos.y - myPos.y;
+                float dirX = diffX < 0 ? -1 : 1;
+                float dirY = diffY < 0 ? -1 : 1;
+                diffX = Mathf.Abs(diffX);
+                diffY = Mathf.Abs(diffY);
+                
                 if (diffX > diffY) {
                     transform.Translate(Vector3.right * dirX * 40);
                 } else if (diffX < diffY) {

--- a/VampireSurvivors/Assets/Scripts/Reposition.cs
+++ b/VampireSurvivors/Assets/Scripts/Reposition.cs
@@ -36,7 +36,9 @@ public class Reposition : MonoBehaviour {
                 break;
             case "Enemy":
                 if (coll.enabled) {
-                    transform.Translate(playerDir * 20 + new Vector3(Random.Range(-3f, 3f), Random.Range(-3f, 3f), 0f));
+                    Vector3 dist = playerPos - myPos;
+                    Vector3 ran = new Vector3(Random.Range(-3, 3), Random.Range(-3, 3), 0);
+                    transform.Translate(ran + dist * 2);
                 }
                 break;
         }

--- a/VampireSurvivors/Assets/Scripts/Spawner.cs
+++ b/VampireSurvivors/Assets/Scripts/Spawner.cs
@@ -8,18 +8,21 @@ public class Spawner : MonoBehaviour {
 
 	public Transform[] spawnPoint;
 	public SpawnData[] spawnDatas;
+	public float levelTime;
+	
 	private int level;
 	private float timer;
 
 	private void Awake() {
 		spawnPoint = GetComponentsInChildren<Transform>();
+		levelTime = GameManager.instance.maxGameTime / spawnDatas.Length;
 	}
 
 	private void Update() {
 		if(!GameManager.instance.isLive) return;
 		
 		timer += Time.deltaTime;
-		level = Mathf.Min(Mathf.FloorToInt(GameManager.instance.gameTime / 10f), spawnDatas.Length - 1);
+		level = Mathf.Min(Mathf.FloorToInt(GameManager.instance.gameTime / levelTime), spawnDatas.Length - 1);
 		
 		if (timer > spawnDatas[level].spawnTime) {
 			Spawn();

--- a/VampireSurvivors/Assets/Scripts/Weapon.cs
+++ b/VampireSurvivors/Assets/Scripts/Weapon.cs
@@ -100,7 +100,7 @@ public class Weapon : MonoBehaviour {
 			Vector3 rotVec = Vector3.forward * 360 * i / count;
 			bullet.Rotate(rotVec);
 			bullet.Translate(bullet.up * 1.3f, Space.World);
-			bullet.GetComponent<Bullet>().Init(damage, -1, Vector3.zero); // -1 은 무한관통.
+			bullet.GetComponent<Bullet>().Init(damage, -100, Vector3.zero); // -100 은 무한관통.
 		}
 	}
 


### PR DESCRIPTION
- 방향키 입력 여부와 상관없이 맵 위치 조정되도록 수정
- 몬스터 위치 재배치도 플레이어와의 거리로만 계산되도록 수정
- 원거리 무기 per가 -1이 되었을 때 생기는 이슈 수정
  - 근거리 무기의 per를 -100으로 조정
- 몬스터 스폰 시간 하드코딩 부분 수정
- 레벨업 경험치 조정
- 게임 전체 시간 300초로 조정